### PR TITLE
fixed Facade path since there is no Controller directory

### DIFF
--- a/src/SCollins/SteamAuth/SteamAuthFacade.php
+++ b/src/SCollins/SteamAuth/SteamAuthFacade.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 class SteamAuthFacade extends Facade {
  
     protected static function getFacadeAccessor() {
-        return 'SCollins\SteamAuth\Http\Controller\SteamController';
+        return 'SCollins\SteamAuth\Http\SteamController';
     }
  
 }


### PR DESCRIPTION
thanks for sharing your code, i used it to create a laravel-plugin for a different OpenID provider.
in the process i found that the path for including the Facade had an extra directory Controller in it.
